### PR TITLE
Fix bugs and drop support for Postgres >= 9.0

### DIFF
--- a/META.json
+++ b/META.json
@@ -15,13 +15,21 @@
             "version": "0.5.0"
         }
     },
-    
+
+    "prereqs": {
+        "runtime": {
+           "requires": {
+              "PostgreSQL": "9.1.0"
+           }
+        }
+     },
+
     "release_status": "stable",
     
     "resources": {
         "repository": {
-          "url":  "https://github.com/bgiles/pg_complex/complex.git",
-          "web":  "https://github.com/bgiles/pg_complex/complex",
+          "url":  "https://github.com/beargiles/pg-complex/complex.git",
+          "web":  "https://github.com/beargiles/pg-complex/complex",
           "type": "git"
         }
     },

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,19 @@
 EXTENSION    = complex
 EXTVERSION   = $(shell grep default_version $(EXTENSION).control | sed -e "s/default_version[[:space:]]*=[[:space:]]*'\([^']*\)'/\1/")
-
-DATA         = $(filter-out $(wildcard sql/*--*.sql),$(wildcard sql/*.sql))
+DATA         = sql/$(EXTENSION)--$(EXTVERSION).sql
 DOCS         = $(wildcard doc/*.md)
 TESTS        = $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
-REGRESS_OPTS = --inputdir=test --load-language=plpgsql
+REGRESS_OPTS = --inputdir=test
 MODULES      = $(patsubst %.c,%,$(wildcard src/*.c))
-PG_CONFIG    = pg_config
-PG91         = $(shell $(PG_CONFIG) --version | grep -qE " 8\.| 9\.0" && echo no || echo yes)
+PG_CONFIG   ?= pg_config
 
-ifeq ($(PG91),yes)
 all: sql/$(EXTENSION)--$(EXTVERSION).sql
 
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
-DATA = $(wildcard sql/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
-endif
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/README.md
+++ b/README.md
@@ -44,14 +44,13 @@ package management system such as RPM to install PostgreSQL, be sure that the
 `-devel` package is also installed. If necessary tell the build process where
 to find it:
 
-    env PG_CONFIG=/path/to/pg_config make && make installcheck && make install
+    env PG_CONFIG=/path/to/pg_config make && make install && make installcheck
 
-And finally, if all that fails (and if you're on PostgreSQL 8.1 or lower, it
-likely will), copy the entire distribution directory to the `contrib/`
-subdirectory of the PostgreSQL source tree and try it there without
+And finally, if all that fails, copy the entire distribution directory to the
+`contrib/` subdirectory of the PostgreSQL source tree and try it there without
 `pg_config`:
 
-    env NO_PGXS=1 make && make installcheck && make install
+    env NO_PGXS=1 make && make install && make installcheck
 
 If you encounter an error such as:
 
@@ -62,27 +61,10 @@ You need to run the test suite using a super user, such as the default
 
     make installcheck PGUSER=postgres
 
-Once pg_complex is installed, you can add it to a database. If you're running
-PostgreSQL 9.1.0 or greater, it's a simple as connecting to a database as a
-super user and running:
+Once pg_complex is installed, you can add it to a database by connecting to a
+database as a super user and running:
 
     CREATE EXTENSION pg_complex;
-
-If you've upgraded your cluster to PostgreSQL 9.1 and already had pg_complex
-installed, you can upgrade it to a properly packaged extension with:
-
-    CREATE EXTENSION pg_complex FROM unpackaged;
-
-For versions of PostgreSQL less than 9.1.0, you'll need to run the
-installation script:
-
-    psql -d mydb -f /path/to/pgsql/share/contrib/pg_complex.sql
-
-If you want to install pg_complex and all of its supporting objects into a specific
-schema, use the `PGOPTIONS` environment variable to specify the schema, like
-so:
-
-    PGOPTIONS=--search_path=extensions psql -d mydb -f pg_complex.sql
 
 Dependencies
 ------------

--- a/doc/complex.md
+++ b/doc/complex.md
@@ -67,7 +67,7 @@ Support
 -------
 
 The most recent version of this project can be found at 
-http://github.com/beargiles/pg_complex.
+http://github.com/beargiles/pg-complex.
 
 
 Author

--- a/test/expected/math_1.out
+++ b/test/expected/math_1.out
@@ -1,0 +1,93 @@
+\set ECHO None
+\set c1 (1,2)::complex
+\set c2 (1,1)::complex
+\set c3 (3,4)::complex
+\set c4 (3,8)::complex
+SELECT 1::complex AS a, (1::int8)::complex AS b, 1.0::complex AS c;
+   a   |   b   |   c   
+-------+-------+-------
+ (1,0) | (1,0) | (1,0)
+(1 row)
+
+SELECT (1,2)::complex AS a, -(1,2)::complex AS b, ~(1,2)::complex AS c;
+   a   |    b    |   c    
+-------+---------+--------
+ (1,2) | (-1,-2) | (1,-2)
+(1 row)
+
+SELECT :c1 + (3,4)::complex AS a, 3 + :c1 AS b, :c1 + 3 AS c;
+   a   |   b   |   c   
+-------+-------+-------
+ (4,6) | (4,2) | (4,2)
+(1 row)
+
+SELECT :c1 - (3,6)::complex AS a, 3 - :c1 AS b, :c1 - 3 AS c;
+    a    |   b    |   c    
+---------+--------+--------
+ (-2,-4) | (2,-2) | (-2,2)
+(1 row)
+
+SELECT :c1 * (3,5)::complex AS a, 3 * :c1 AS b, :c1 * 3 AS c;
+    a    |   b   |   c   
+---------+-------+-------
+ (-7,11) | (3,6) | (3,6)
+(1 row)
+
+SELECT :c1 * (3,5)::complex AS a, 3.0::double precision * :c1 AS b, :c1 * 3.0 AS c;
+    a    |   b   |   c   
+---------+-------+-------
+ (-7,11) | (3,6) | (3,6)
+(1 row)
+
+SELECT :c4 / :c1  AS a, (:c4 / :c1) * :c1 = :c4 AS b;
+     a     | b 
+-----------+---
+ (3.8,0.4) | t
+(1 row)
+
+SELECT :c4 / (2,0)::complex AS a, (2,0)::complex * (:c4 / (2,0)::complex)  = :c4 AS b;
+    a    | b 
+---------+---
+ (1.5,4) | t
+(1 row)
+
+SELECT :c4 / (0,2)::complex AS a, (0,2)::complex * (:c4 / (0,2)::complex) = :c4 AS b;
+    a     | b 
+----------+---
+ (4,-1.5) | t
+(1 row)
+
+SELECT :c4 / 3 AS a, 3 * (:c4 / 3) = :c4 AS b;
+           a            | b 
+------------------------+---
+ (1,2.6666666666666665) | t
+(1 row)
+
+SELECT 3 / :c4 AS a, :c4 * (3 / :c4) = 3::complex AS b;
+                    a                     | b 
+------------------------------------------+---
+ (0.1232876712328767,-0.3287671232876712) | t
+(1 row)
+
+--
+-- check magnitude
+--
+SELECT magnitude(:c1) AS magnitude;
+    magnitude     
+------------------
+ 2.23606797749979
+(1 row)
+
+SELECT magnitude(:c2) AS magnitude;
+     magnitude      
+--------------------
+ 1.4142135623730951
+(1 row)
+
+SELECT magnitude(:c3) AS magnitude;
+ magnitude 
+-----------
+         5
+(1 row)
+
+ROLLBACK;


### PR DESCRIPTION
`complex--0.5.0.sql` was ending up in the `DATA` variable, which causes newer versions of `make` to error out. So simplify the `Makefile` a bit by requiring Postgres 9.1 and removing the conditional code. Also remove references to installing the extension on earlier versions of Postgres.

Requires Postgres 9.1 in `META.json` and fix the GitHub URLs.

Add a second expected output for updated formatting on newer versions of Postgres (I tested with 16.2).